### PR TITLE
Fix incorrect decoding of "start" tag

### DIFF
--- a/src/BinTreeNodeReader.php
+++ b/src/BinTreeNodeReader.php
@@ -284,7 +284,8 @@ class BinTreeNodeReader
         $size = $this->readListSize($this->readInt8());
         $token = $this->readInt8();
         if ($token == 1) {
-            $token = $this->readInt8();
+            $attributes = $this->readAttributes($size);		
+            return new ProtocolNode("start", $attributes, null, "");
         }
         if ($token == 2) {
             return;


### PR DESCRIPTION
When decoding stream from real app (v2.12.367 protocol v1.6) this will decode it incorrectly while previous version of `start` decoding will work correctly. Reverted to older version.
